### PR TITLE
fix: remove Chart.js CDN link and import Chart.js module in chart.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,8 +67,6 @@
         </div>
       </div>
     </main>
-
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script type="module" src="src/main.js"></script>
   </body>
 </html>

--- a/src/chart.js
+++ b/src/chart.js
@@ -2,6 +2,7 @@ import {
   calculateEmissionsByCategory,
   formatEmissions,
 } from "./calculations.js";
+import Chart from "chart.js/auto";
 
 const CATEGORY_COLORS = {
   Transport: "#2196f3",


### PR DESCRIPTION
This pull request updates how Chart.js is loaded in the project by switching from a CDN script tag in `index.html` to importing Chart.js as an ES module in the JavaScript source code. This change helps ensure better module management and compatibility with modern JavaScript tooling.

**Dependency management improvements:**

* Removed the Chart.js CDN script tag from `index.html` to prevent global script loading.
* Added an ES module import for Chart.js in `src/chart.js`, allowing for direct usage within the module system.